### PR TITLE
fix: added permissions to publish test results

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     if: "!startsWith(github.event.head_commit.message, 'ci(release):')"
 
+    permissions:
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
The `maven-verify` job currently fails with the following error:
```
Error: HttpError: Resource not accessible by integration
```

This is caused by the `GITHUB_TOKEN` having only read permissions by default (see [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions)).  To counteract that we should explicitly define write permissions for pull-requests.